### PR TITLE
Ignore npm-debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ runners/debug/
 *.remote
 *.local
 .DS_store
+npm-debug.log


### PR DESCRIPTION
Ignore the npm-debug.log, this can happen on failing `npm i` and should be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/itframe/6)
<!-- Reviewable:end -->
