### PR TITLE
Centova nocover API

### DIFF
--- a/src/components/centova/nocover.js
+++ b/src/components/centova/nocover.js
@@ -1,0 +1,22 @@
+const mongoose = requireFromRoot("components/database/mongodb.js");
+const Schema = mongoose.Schema;
+const nocoverSchema = new Schema({
+    username: String,
+    link: String,
+}, { collection: "centova_nocover", read: "nearest" });
+const nocoverModel = mongoose.model("centova_nocover", nocoverSchema, "centova_nocover");
+
+export const nocoverForUserame = (username) => {
+    return nocoverModel.findOne({
+        username,
+    }).exec()
+}
+export const updateNocoverForUsername = async (username, link) => {
+    let entry = await nocoverModel.findOne({ username }).exec()
+    if (entry === null) {
+        entry = new nocoverModel()
+        entry.username = username
+    }
+    entry.link = link
+    return entry.save()
+}

--- a/src/http/control/centova-nocover.js
+++ b/src/http/control/centova-nocover.js
@@ -1,0 +1,80 @@
+const ALLOWED_IMAGE_TYPES = ["jpg", "jpeg", "png", "gif"];
+const DIMENSIONS = {
+    nocover: { width: 50, height: 50 },
+};
+
+let moduleLogger = log.child({ component: "centova-nocover" });
+let multer = require("multer");
+let sbuff = require("simple-bufferstream");
+let getFileType = require("file-type");
+import S3MulterStorage from "~/components/storage/S3MulterStorage";
+import convertImage from "~/components/bufferImageConvert";
+import resizeImage from "~/components/bufferImageResize";
+
+let processImageUpload = (req, { stream }, callback) => {
+    let logger = moduleLogger.child({ req });
+    let targetDimensions = DIMENSIONS[req.query.imageType];
+    let chunks = [];
+    stream.on("data", (data) => chunks.push(data));
+    stream.on("end", () => {
+        let buffer = Buffer.concat(chunks);
+        let type = getFileType(buffer);
+        if (!type) {
+            return callback(new Error("Unknown file."));
+        }
+        if (type.ext && ALLOWED_IMAGE_TYPES.indexOf(type.ext) === -1) {
+            return callback(new Error("Invalid file."));
+        }
+        if (!targetDimensions) {
+            logger.info("Converting image to PNG");
+            convertImage(buffer, type.ext, (convertError, convertedBuffer) => {
+                if (convertError) {
+                    logger.error(convertError, "Failed to resize the image");
+                    return callback(convertError);
+                }
+                logger.info("Successfully converted the image")
+                return callback(null, sbuff(convertedBuffer));
+            });
+        } else {
+            logger.info("Resizing image and converting it to PNG");
+            resizeImage(buffer, type.ext, targetDimensions, (resizeError, resizedBuffer) => {
+                if (resizeError) {
+                    logger.error(resizeError, "Failed to resize the image");
+                    return callback(resizeError);
+                }
+                logger.info("Successfully resized the image")
+                return callback(null, sbuff(resizedBuffer));
+            });
+        }
+    });
+};
+const ONE_MEGABYTE = 1 * Math.pow(10, 6);
+const MAX_FILE_SIZE = 5 * ONE_MEGABYTE;
+let upload = multer({
+    storage: new S3MulterStorage({
+        container: config.appImagesUploadContainer,
+        processFileFn: processImageUpload,
+        defaultExtension: "png",
+    }),
+    limits: {
+        fileSize: MAX_FILE_SIZE,
+    },
+    fileFilter: (req, file, cb) => {
+        let splitFileName = file.originalname.split(".");
+        let fileExtension = splitFileName[splitFileName.length - 1];
+        cb(null, ALLOWED_IMAGE_TYPES.indexOf(fileExtension) !== -1);
+    },
+});
+
+module.exports = function ({ app }) {
+    app.post("/control/centova/upload-nocover", upload.single("nocover"), (req, res) => {
+        if (!req.file) {
+            throw new Error("Failed to upload the image.");
+        }
+        req.log.info({ link: req.file.link }, "Uploaded file");
+        res.json({
+            link: `https://images.shoutca.st/${req.file.name}`,
+            name: req.file.name,
+        });
+    });
+};

--- a/src/http/public/centova.js
+++ b/src/http/public/centova.js
@@ -1,0 +1,12 @@
+import BadRequestError from "~/http/classes/BadRequestError"
+const nocover = requireFromRoot("components/centova/nocover.js")
+
+module.exports = ({ app, wrap }) => {
+    app.get("/centova/nocover/:username", wrap(async (req, res) => {
+        if (!req.params.username) {
+            throw new BadRequestError("Missing username")
+        }
+        res.json(await nocover.nocoverForUserame(req.params.username))
+    }))
+}
+


### PR DESCRIPTION
We have been getting a lot of requests to change the nocover image in Centova Cast. Since Centova has not been built this feature in ages we decided to do it our way.

This API allows uploading an image in Control that will be converted to png and the proper (meaning the only size that doesn't f*ck up the Centova Cast look) size then hosts it on our image CDN accessible via a public API. 

This public API will then be queried by a script with the right privileges to replace the file in Centova Cast.